### PR TITLE
Mudando iFood para Integra-Vendas

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Integra - Vendas
 
 ![license mit](https://img.shields.io/badge/license-MIT-blue.svg) 
-[![Build Status](https://travis-ci.com/fga-eps-mds/2018.2-iFood.svg?branch=master)](https://travis-ci.com/fga-eps-mds/2018.2-iFood)
-[![docusaurus](https://img.shields.io/badge/doc-Docusaurus-blue.svg)](https://fga-eps-mds.github.io/2018.2-iFood/)
+[![Build Status](https://travis-ci.com/fga-eps-mds/2018.2-Integra-Vendas.svg?branch=master)](https://travis-ci.com/fga-eps-mds/2018.2-Integra-Vendas)
+[![docusaurus](https://img.shields.io/badge/doc-Docusaurus-blue.svg)](https://fga-eps-mds.github.io/2018.2-Integra-Vendas/)
 [![pipeline status](https://gitlab.com/integra-vendas/api-gateway/badges/master/pipeline.svg)](https://gitlab.com/integra-vendas/api-gateway/commits/master)
-[![codecov](https://codecov.io/gh/fga-eps-mds/2018.2-iFood/branch/master/graph/badge.svg)](https://codecov.io/gh/fga-eps-mds/2018.2-iFood)
+[![codecov](https://codecov.io/gh/fga-eps-mds/2018.2-Integra-Vendas/branch/master/graph/badge.svg)](https://codecov.io/gh/fga-eps-mds/2018.2-Integra-Vendas)
 
-* [Documentação do Projeto Integra Vendas](https://fga-eps-mds.github.io/2018.2-iFood/)
+* [Documentação do Projeto Integra Vendas](https://fga-eps-mds.github.io/2018.2-Integra-Vendas/)
 
 * [Documentação do App Integra](https://fga-eps-mds.github.io/2018.2-FGAPP-FrontEnd)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Integra - Vendas
 
 ![license mit](https://img.shields.io/badge/license-MIT-blue.svg) 
-[![Build Status](https://travis-ci.com/fga-eps-mds/2018.2-Integra-Vendas.svg?branch=master)](https://travis-ci.com/fga-eps-mds/2018.2-Integra-Vendas)
+[![Build Status](https://travis-ci.org/fga-eps-mds/2018.2-Integra-Vendas.svg?branch=master)](https://travis-ci.org/fga-eps-mds/2018.2-Integra-Vendas)
 [![docusaurus](https://img.shields.io/badge/doc-Docusaurus-blue.svg)](https://fga-eps-mds.github.io/2018.2-Integra-Vendas/)
 [![pipeline status](https://gitlab.com/integra-vendas/api-gateway/badges/master/pipeline.svg)](https://gitlab.com/integra-vendas/api-gateway/commits/master)
 [![codecov](https://codecov.io/gh/fga-eps-mds/2018.2-Integra-Vendas/branch/master/graph/badge.svg)](https://codecov.io/gh/fga-eps-mds/2018.2-Integra-Vendas)

--- a/docs/docs/alta-fidelidade.md
+++ b/docs/docs/alta-fidelidade.md
@@ -4,7 +4,7 @@ title: Alta Fidelidade
 sidebar_label: Alta Fidelidade
 ---
 
-A partir dos fluxos de telas definidos pelo [protótipo de baixa fidelidade](/2018.2-iFood/docs/baixa-fidelidade) e dos padrões definido pelo [guia de identidade visual](/2018.2-iFood/docs/id-visual), foi produzido um protótipo de alta fidelidade com o design seguindo os padrões de aplicativos do Android na ferramenta de produção de protótipos do [Marvel](https://marvelapp.com/). O protótipo da alta fidelidade teve como objetivo concretizar os padrões visuais do aplicativo e testar a usabilidade com os *stakeholders*.
+A partir dos fluxos de telas definidos pelo [protótipo de baixa fidelidade](/2018.2-Integra-Vendas/docs/baixa-fidelidade) e dos padrões definido pelo [guia de identidade visual](/2018.2-Integra-Vendas/docs/id-visual), foi produzido um protótipo de alta fidelidade com o design seguindo os padrões de aplicativos do Android na ferramenta de produção de protótipos do [Marvel](https://marvelapp.com/). O protótipo da alta fidelidade teve como objetivo concretizar os padrões visuais do aplicativo e testar a usabilidade com os *stakeholders*.
 
 A seção [Fluxo de telas](#fluxo-de-telas) apresenta as telas desenvolvidas a demonstrando o fluxo principal do aplicativo no serviço de vendas e na aba de configurações. O acesso ao protótipo de alta fidelidade está na seção [Protótipo no Marvel](#prototipo-no-marvel).
 

--- a/docs/docs/sprint4.md
+++ b/docs/docs/sprint4.md
@@ -40,10 +40,10 @@ sidebar_label: Sprint 4
 
 -------------------------------------------------------------------------------
 # Revisão da Sprint
-* A [US01](https://github.com/fga-eps-mds/2018.2-iFood/issues/36) entregou valor, pois preencheu todos os critérios de aceitação. No entanto, gerou a [TS04](https://github.com/fga-eps-mds/2018.2-iFood/issues/82) para o desenvolvimento de testes unitários das funcionalidades implementadas.
-* A [TS01](https://github.com/fga-eps-mds/2018.2-iFood/issues/78) foi feita por completo.
-* A [TS02](https://github.com/fga-eps-mds/2018.2-iFood/issues/79) foi feita por completo.
-* A [US08](https://github.com/fga-eps-mds/2018.2-iFood/issues/46) não preencheu todos os critérios de aceitação.
+* A [US01](https://github.com/fga-eps-mds/2018.2-Integra-Vendas/issues/36) entregou valor, pois preencheu todos os critérios de aceitação. No entanto, gerou a [TS04](https://github.com/fga-eps-mds/2018.2-Integra-Vendas/issues/82) para o desenvolvimento de testes unitários das funcionalidades implementadas.
+* A [TS01](https://github.com/fga-eps-mds/2018.2-Integra-Vendas/issues/78) foi feita por completo.
+* A [TS02](https://github.com/fga-eps-mds/2018.2-Integra-Vendas/issues/79) foi feita por completo.
+* A [US08](https://github.com/fga-eps-mds/2018.2-Integra-Vendas/issues/46) não preencheu todos os critérios de aceitação.
 
 -------------------------------------------------------------------------------
 # Métricas

--- a/docs/docs/sprint5.md
+++ b/docs/docs/sprint5.md
@@ -48,11 +48,11 @@ sidebar_label: Sprint 5
 
 -------------------------------------------------------------------------------
 # Revisão da Sprint
-* A [US08](https://github.com/fga-eps-mds/2018.2-iFood/issues/46) foi feita por completo.
-* A [US02](https://github.com/fga-eps-mds/2018.2-iFood/issues/40) foi feita por completo.
-* A [US11](https://github.com/fga-eps-mds/2018.2-iFood/issues/83) foi feita por completo.
-* A [US10](https://github.com/fga-eps-mds/2018.2-iFood/issues/48) não preencheu todos os critérios de aceitação.
-* A [US06](https://github.com/fga-eps-mds/2018.2-iFood/issues/44) foi feita por completo.
+* A [US08](https://github.com/fga-eps-mds/2018.2-Integra-Vendas/issues/46) foi feita por completo.
+* A [US02](https://github.com/fga-eps-mds/2018.2-Integra-Vendas/issues/40) foi feita por completo.
+* A [US11](https://github.com/fga-eps-mds/2018.2-Integra-Vendas/issues/83) foi feita por completo.
+* A [US10](https://github.com/fga-eps-mds/2018.2-Integra-Vendas/issues/48) não preencheu todos os critérios de aceitação.
+* A [US06](https://github.com/fga-eps-mds/2018.2-Integra-Vendas/issues/44) foi feita por completo.
 -------------------------------------------------------------------------------
 # Métricas
 ![tempo-mds-5](assets/sprints/tempo-mds-5.png)

--- a/docs/website/siteConfig.js
+++ b/docs/website/siteConfig.js
@@ -24,13 +24,13 @@ const siteConfig = {
   title: 'Integra Vendas', // Title for your website.
   tagline: 'Documentação do Projeto Integra Vendas',
 
-  url: 'https://fga-eps-mds.github.io/2018.2-iFood/', // Your website URL
-  baseUrl: '/2018.2-iFood/', // Base URL for your project */
+  url: 'https://fga-eps-mds.github.io/2018.2-Integra-Vendas/', // Your website URL
+  baseUrl: '/2018.2-Integra-Vendas/', // Base URL for your project */
   // Localhost
   // baseUrl: '/', // Base URL for your project */
 
   // Used for publishing and more
-  projectName: '2018.2-iFood',
+  projectName: '2018.2-Integra-Vendas',
   organizationName: 'fga-eps-mds',
   // For top-level user or org sites, the organization is still the same.
   // e.g., for the https://JoelMarcey.github.io site, it would be set like...


### PR DESCRIPTION
## Descrição
Alteração do nome quebrou os links e referencias ao repositório. 

Nesse PR foi feito apenas a substituição para Integra-Vendas