### PR TITLE
Adicionando testes básicos de integração de login e registro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.vscode
+.env
+.DS_Store

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,27 +3,6 @@ stages:
   - publish
   - deploy
 
-unit tests:
-  image: python:3.5.6-slim-stretch
-  before_script:
-    - pip install -r api/api_gateway/requirements/dev.txt
-  stage: test
-  script:
-    - cd api && sh run-tests.sh
-
-publish codecov:
-  image: python:3.5.6-slim-stretch
-  before_script:
-    - pip install -r api/api_gateway/requirements/dev.txt
-  only:
-    - master
-  stage: publish
-  dependencies:
-    - unit tests
-  script:
-    - cd api && sh run-tests.sh
-    - cd api_gateway && codecov -t ${CODECOV_TOKEN}
-
 # github pages
 publish pages:
   image: docker:stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,11 @@ jobs:
       if: branch = dev
       script: make staging-integration-tests
 
+    - stage: "Publish codecov"
+      name: "Publishing test coverage"
+      # if: branch = dev
+      script: sh publish-codecov.sh dc-integration-test.staging.yml
+
     - stage: "Production Tests"
       name: "Unit Integrated Tests"
       if: branch = master

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,14 +34,12 @@ jobs:
     - stage: "Staging Tests"
       name: "Unit Integrated Tests"
       if: branch = dev
-      script: make staging-integration-tests
+      script:
+        - make integration-tests file=dc-integration-test.staging.yml
 
-    - stage: "Publish codecov"
+    - stage: "Test Production and publish codecov"
       name: "Publishing test coverage"
-      # if: branch = dev
-      script: sh publish-codecov.sh dc-integration-test.staging.yml
-
-    - stage: "Production Tests"
-      name: "Unit Integrated Tests"
       if: branch = master
-      script: make production-integration-tests
+      script:
+        - make integration-tests file=dc-integration-test.production.yml
+        - cd api/api_gateway && codecov -t ${CODECOV_TOKEN}

--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,13 @@ run:
 integration-tests:
 	docker-compose -f ${file} build
 	docker-compose -f ${file} up -d
-	docker exec api-gateway bash -c "sh run-integration-tests.sh"
+	docker exec api-gateway bash -c "sh run-tests.sh"
 	docker-compose -f ${file} rm -f -s
 
 staging-integration-tests:
+	sh remove-all-containers.sh || true
 	make integration-tests file=dc-integration-test.staging.yml
 
 production-integration-tests:
+	sh remove-all-containers.sh || true
 	make integration-tests file=dc-integration-test.production.yml

--- a/api/api_gateway/api/tests/__init__.py
+++ b/api/api_gateway/api/tests/__init__.py
@@ -1,0 +1,4 @@
+from .test_login import *
+from .test_order import *
+from .test_product import *
+from .test_version import *

--- a/api/api_gateway/api/tests/login_test_helper.py
+++ b/api/api_gateway/api/tests/login_test_helper.py
@@ -1,0 +1,30 @@
+from django.conf import settings
+import requests
+
+default_password = "test1234"
+
+def registrate_new_user(email):
+    
+    data = {
+        "username": email,
+        "email": email,
+        "password1": default_password,
+        "password2": default_password
+    }
+
+    response = requests.post(settings.LOGIN + '/api/registration/', data=data)
+
+    return response.json()
+
+def login_user(email):
+
+    data = {
+        "username": email,
+        "password": default_password
+    }
+
+    response = requests.post(settings.LOGIN + '/api/login/', data=data)
+
+    return response.json()
+
+

--- a/api/api_gateway/api/tests/test_login.py
+++ b/api/api_gateway/api/tests/test_login.py
@@ -1,0 +1,33 @@
+from django.test import TestCase
+from .login_test_helper import registrate_new_user, login_user
+
+
+# Create your tests here.
+class LoginTest(TestCase):
+
+    def test_user_registration(self):
+
+        email = 'robson@hotmail.com'
+        
+        responseJson = registrate_new_user(email)
+
+        token = responseJson['token']
+        user = responseJson['user']
+
+        self.assertEqual(user["email"], email)
+
+    def test_user_login(self):
+
+        email = 'serib@email.com'
+
+        responseJson = registrate_new_user(email)
+        loginResponseJson = login_user(email)
+
+        login_token = loginResponseJson["token"]
+        user = loginResponseJson["user"]
+
+        registration_token = responseJson['token']
+
+        self.assertEqual(user["email"], email)
+        self.assertEqual(registration_token, login_token)
+

--- a/api/api_gateway/api/tests/test_order.py
+++ b/api/api_gateway/api/tests/test_order.py
@@ -1,0 +1,6 @@
+from django.test import TestCase
+
+# Create your tests here.
+class OrderTest(TestCase):
+    def test_truthiness(self):
+        self.assertEqual(True, True)

--- a/api/api_gateway/api/tests/test_product.py
+++ b/api/api_gateway/api/tests/test_product.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 
 # Create your tests here.
-class PlaceholderTest(TestCase):
+class ProductTest(TestCase):
     def test_truthiness(self):
         self.assertEqual(True, True)

--- a/api/api_gateway/api/tests/test_version.py
+++ b/api/api_gateway/api/tests/test_version.py
@@ -1,0 +1,6 @@
+from django.test import TestCase
+
+# Create your tests here.
+class VersionTest(TestCase):
+    def test_truthiness(self):
+        self.assertEqual(True, True)

--- a/api/api_gateway/run-tests.sh
+++ b/api/api_gateway/run-tests.sh
@@ -1,4 +1,7 @@
 pip install -r requirements/dev.txt
 python manage.py makemigrations
 python manage.py migrate
-python manage.py test
+
+rm -rf .coverage
+coverage run manage.py test
+coverage report || true

--- a/api/run-tests.sh
+++ b/api/run-tests.sh
@@ -1,8 +1,2 @@
 cd api_gateway
-pip install -r requirements/dev.txt
-python manage.py makemigrations
-python manage.py migrate
-
-rm -rf .coverage
-coverage run manage.py test
-coverage report || true
+sh run-tests.sh

--- a/publish-codecov.sh
+++ b/publish-codecov.sh
@@ -1,5 +1,0 @@
-docker-compose -f $1 build
-docker-compose -f $1 up -d
-docker-compose -f $1 exec api bash -c "sh run-tests.sh"
-docker-compose -f $1 rm -f -s
-cd api/api_gateway && codecov -t ${CODECOV_TOKEN}

--- a/publish-codecov.sh
+++ b/publish-codecov.sh
@@ -1,4 +1,5 @@
 docker-compose -f $1 build
 docker-compose -f $1 up -d
-docker exec api-gateway -e CODECOV_TOKEN=${CODECOV_TOKEN} bash -c "sh run-tests.sh && cd api_gateway && codecov -t ${CODECOV_TOKEN}"
+docker-compose -f $1 exec api bash -c "sh run-tests.sh"
 docker-compose -f $1 rm -f -s
+cd api/api_gateway && codecov -t ${CODECOV_TOKEN}

--- a/publish-codecov.sh
+++ b/publish-codecov.sh
@@ -1,0 +1,4 @@
+docker-compose -f $1 build
+docker-compose -f $1 up -d
+docker exec api-gateway -e CODECOV_TOKEN=${CODECOV_TOKEN} bash -c "sh run-tests.sh && cd api_gateway && codecov -t ${CODECOV_TOKEN}"
+docker-compose -f $1 rm -f -s

--- a/remove-all-containers.sh
+++ b/remove-all-containers.sh
@@ -1,0 +1,2 @@
+docker stop $(docker ps -a -q)
+docker rm $(docker ps -a -q)


### PR DESCRIPTION
## Descrição
A fim de organizar como vai ocorrer os testes de integração, foram realizados testes simples de login e registro de usuário. Foi constatado que como o banco de dados esta em um serviço separado, ao realizar os testes na api-gateway, o banco de dados não é limpo, logo todos os testes compartilham dos mesmos serviços, e os testes então, devem seguir uma política diferenciada.

- [x] Criei testes unitários
- [x] Todos os testes estão passando
- [x] Estou utilizando o ambiente configurado
