### PR TITLE
Hotfix/integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,14 +6,16 @@ run:
 
 integration-tests:
 	docker-compose -f ${file} build
-	docker-compose -f ${file} up &
+	docker-compose -f ${file} up -d
 	echo "Running Integration Tests"
-	docker exec api-gateway bash -c "sh run-tests.sh"
+	docker exec api-gateway bash -c "bash ./check-services.sh && sh run-tests.sh"
+	docker-compose -f ${file} down
 	docker-compose -f ${file} rm -f -s
 
 staging-integration-tests:
 	sh remove-all-containers.sh || true
 	make integration-tests file=dc-integration-test.staging.yml
+	
 
 production-integration-tests:
 	sh remove-all-containers.sh || true

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ run:
 	cd api && make run
 
 integration-tests:
-	docker-compose -f ${file} build
 	docker-compose -f ${file} up -d
 	echo "Running Integration Tests"
 	docker exec api-gateway bash -c "bash ./check-services.sh && sh run-tests.sh"

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ run:
 
 integration-tests:
 	docker-compose -f ${file} build
-	docker-compose -f ${file} up -d
+	docker-compose -f ${file} up &
+	echo "Running Integration Tests"
 	docker exec api-gateway bash -c "sh run-tests.sh"
 	docker-compose -f ${file} rm -f -s
 
@@ -17,3 +18,8 @@ staging-integration-tests:
 production-integration-tests:
 	sh remove-all-containers.sh || true
 	make integration-tests file=dc-integration-test.production.yml
+
+backend:
+	sh remove-all-containers.sh || true
+	docker-compose -f dc-backend-production.yml build
+	docker-compose -f dc-backend-production.yml up 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -9,3 +9,6 @@ ADD ./api_gateway /code/
 
 RUN pip install --upgrade pip
 RUN pip install -r requirements/dev.txt
+
+RUN apt-get update
+RUN apt-get install curl libcurl3 libcurl3-dev -y

--- a/api/Makefile
+++ b/api/Makefile
@@ -1,10 +1,12 @@
 default:
 	docker network create api-backend || true
-	docker-compose build
 	docker-compose up
 
 run:
 	echo NEED_UPDATE
+
+build:
+	docker-compose build
 
 enter:
 	docker-compose exec web bash

--- a/api/Makefile
+++ b/api/Makefile
@@ -13,4 +13,5 @@ test:
 	docker-compose exec web bash -c "cd api_gateway && python manage.py test"
 
 production:
+	docker-compose -f docker-compose-production.yml build
 	docker-compose -f docker-compose-production.yml up

--- a/api/api_gateway/api_gateway/settings/production-test.py
+++ b/api/api_gateway/api_gateway/settings/production-test.py
@@ -1,0 +1,15 @@
+from api_gateway.settings.common import *
+
+SECRET_KEY = 'mlcq%tp1&*4k@l*s%nef41*2r6*r+zejfip_dv*0$(&#!jt3pj'
+
+ALLOWED_HOSTS = ['*']
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql',
+        'NAME': 'postgres',
+        'USER': 'postgres',
+        'HOST': 'db', # set in docker-compose.yml	
+        'PORT': 5432 # default postgres port	
+    }
+}

--- a/api/api_gateway/api_gateway/settings/production.py
+++ b/api/api_gateway/api_gateway/settings/production.py
@@ -1,6 +1,10 @@
 from api_gateway.settings.common import *
 
+import django
+django.setup()
+
 DEBUG = False
+
 SECRET_KEY = os.environ.get('SECRET_KEY')
 
 ALLOWED_HOSTS = [os.environ.get('HOST')]

--- a/api/api_gateway/api_gateway/wsgi.py
+++ b/api/api_gateway/api_gateway/wsgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "api_gateway.settings")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "api_gateway.settings.development")
 
 application = get_wsgi_application()

--- a/api/api_gateway/check-services.sh
+++ b/api/api_gateway/check-services.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+red="\033[1;31m"
+green="\033[1;32m"
+nocolor="\033[0m"
+
+# echo "checking internet connectivity..."
+# if [ $(curl --write-out %{http_code} --silent --output /dev/null https://google.com ) == 000 ]
+# then
+#     echo "${red}not connected with the internet...${nocolor}"
+# else
+#     echo "${green}connected with the internet...${nocolor}"
+# fi
+
+declare -a services=(
+                    "http://login-microservice:8000" 
+                    "http://product-microservice:8000"
+                    "http://order-microservice:8000"
+                    )
+
+for s in "${services[@]}"
+do
+    retries=30
+    while [ "$(curl --write-out %{http_code} --silent --output /dev/null ${s})" == "000" ]
+    do
+        echo "✘ ${s} not connected"
+        sleep 1
+        echo "retry: $((--retries))"
+        if [ $retries == 0 ]
+        then
+            exit 0;
+        fi
+    done
+    echo " ✓  ${s} connected!"
+done

--- a/api/api_gateway/check-services.sh
+++ b/api/api_gateway/check-services.sh
@@ -20,7 +20,7 @@ declare -a services=(
 
 for s in "${services[@]}"
 do
-    retries=30
+    retries=60
     while [ "$(curl --write-out %{http_code} --silent --output /dev/null ${s})" == "000" ]
     do
         echo "✘ ${s} not connected"

--- a/api/api_gateway/requirements.txt
+++ b/api/api_gateway/requirements.txt
@@ -1,3 +1,1 @@
 -r requirements/prod.txt
-gunicorn
-django-heroku

--- a/api/api_gateway/requirements/prod.txt
+++ b/api/api_gateway/requirements/prod.txt
@@ -1,1 +1,2 @@
 -r base.txt
+gunicorn

--- a/api/docker-compose-production.yml
+++ b/api/docker-compose-production.yml
@@ -9,7 +9,7 @@ services:
     build:
       context: .
       dockerfile: production.Dockerfile
-    command: bash -c "python manage.py makemigrations && python manage.py migrate && python manage.py runserver 0.0.0.0:8000"
+    command: bash -c "gunicorn --bind 0.0.0.0:8000 api_gateway.wsgi --log-file -"
     ports:
       - 5000:8000
     volumes:

--- a/api/production.Dockerfile
+++ b/api/production.Dockerfile
@@ -1,13 +1,12 @@
 FROM python:3.5.6-slim-stretch
 ENV PYTHONUNBUFFERED 1
 
-WORKDIR /code
-
-ADD ./api_gateway /code
+ADD . /code
+WORKDIR /code/api_gateway
 
 RUN pip install --upgrade pip
 RUN pip install -r requirements/prod.txt
 
 EXPOSE 8000
 
-ENTRYPOINT python manage.py makemigrations && python manage.py migrate && python manage.py runserver 0.0.0.0:8000
+ENTRYPOINT python manage.py makemigrations && python manage.py migrate && gunicorn --bind 0.0.0.0:8000 api_gateway.wsgi --log-file -

--- a/api/production.Dockerfile
+++ b/api/production.Dockerfile
@@ -7,6 +7,9 @@ WORKDIR /code/api_gateway
 RUN pip install --upgrade pip
 RUN pip install -r requirements/prod.txt
 
+RUN apt-get update
+RUN apt-get install curl libcurl3 libcurl3-dev -y
+
 EXPOSE 8000
 
 ENTRYPOINT python manage.py makemigrations && python manage.py migrate && gunicorn --bind 0.0.0.0:8000 api_gateway.wsgi --log-file -

--- a/dc-backend-production.yml
+++ b/dc-backend-production.yml
@@ -1,35 +1,50 @@
 version: '3.3'
 
 services:
-  api:
-    build: api
-    container_name: api-gateway
-    command: bash -c "sh run-tests.sh"
+  db:
+    image: postgres:10.1-alpine
     volumes:
-      - ./api:/code
+      - postgres_data:/var/lib/postgresql/data/
+
+  api:
+    container_name: api-gateway
+    build:
+      context: ./api
+      dockerfile: production.Dockerfile
     ports:
       - 5000:8000
+    environment:
+      - DJANGO_SETTINGS_MODULE=api_gateway.settings.production-test
     depends_on:
+      - db
       - login
       - order
       - product
-    stdin_open: true
-    tty: true
+    
 
   login:
     container_name: login-microservice
     image: integravendas/login-microservice:latest
+    depends_on:
+      - db
     ports:
       - 8000:8000
 
   order:
     container_name: order-microservice
     image: integravendas/order-microservice:latest
+    depends_on:
+      - db
     ports:
       - 8001:8000
 
   product:
     container_name: product-microservice
     image: integravendas/product-microservice:latest
+    depends_on:
+      - db
     ports:
       - 8002:8000
+
+volumes:
+  postgres_data:

--- a/dc-integration-test.production.yml
+++ b/dc-integration-test.production.yml
@@ -10,8 +10,6 @@ services:
     build: api
     container_name: api-gateway
     command: bash -c "bash"
-    volumes:
-      - ./api:/code
     ports:
       - 5000:8000
     depends_on:

--- a/dc-integration-test.staging.yml
+++ b/dc-integration-test.staging.yml
@@ -4,9 +4,7 @@ services:
   api:
     build: api
     container_name: api-gateway
-    command: bash -c "sh run-tests.sh"
-    volumes:
-      - ./api:/code
+    command: bash -c "bash"
     ports:
       - 5000:8000
     depends_on:


### PR DESCRIPTION
## Descrição
Os testes de integração necessitam que todos os serviços estejam online para acontecer. Caso o teste executasse antes dos serviços estarem online, o teste lançava exceção de falha na conexão.

soluciona issue #233

Tarefas gerais realizadas
* Script de verificação dos serviços
* Atualizações gerais no Dockerfile e Compose
* Atualização do makefile para executar o script de verificação.
