### PR TITLE
Doc/sprints - Documentando Sprint 8

### DIFF
--- a/docs/docs/sprint10.md
+++ b/docs/docs/sprint10.md
@@ -4,6 +4,20 @@ title: Sprint 10 - 20/10 - 27/10
 sidebar_label: Sprint 10
 ---
 
+# Lista de presença no planejamento
+|Nome|Presença|
+|----|:------:|
+|Lucas Costa||
+|Lucas Pereira||
+|Ricardo Canela||
+|Wesley Araújo||
+|André Pinto||
+|Dâmaso Pereira||
+|Gustavo Lima||
+|Leonardo Medeiros||
+|Shayane Alcântara||
+|Welison Almeida||
+
 # Planejamento da Sprint
 |Par|História|Pontos|
 |---|:------:|:----:|

--- a/docs/docs/sprint11.md
+++ b/docs/docs/sprint11.md
@@ -4,6 +4,20 @@ title: Sprint 11 - 27/10 - 03/11
 sidebar_label: Sprint 11
 ---
 
+# Lista de presença no planejamento
+|Nome|Presença|
+|----|:------:|
+|Lucas Costa||
+|Lucas Pereira||
+|Ricardo Canela||
+|Wesley Araújo||
+|André Pinto||
+|Dâmaso Pereira||
+|Gustavo Lima||
+|Leonardo Medeiros||
+|Shayane Alcântara||
+|Welison Almeida||
+
 # Planejamento da Sprint
 |Par|História|Pontos|
 |---|:------:|:----:|

--- a/docs/docs/sprint12.md
+++ b/docs/docs/sprint12.md
@@ -4,6 +4,20 @@ title: Sprint 12 - 03/11 - 10/11
 sidebar_label: Sprint 12
 ---
 
+# Lista de presença no planejamento
+|Nome|Presença|
+|----|:------:|
+|Lucas Costa||
+|Lucas Pereira||
+|Ricardo Canela||
+|Wesley Araújo||
+|André Pinto||
+|Dâmaso Pereira||
+|Gustavo Lima||
+|Leonardo Medeiros||
+|Shayane Alcântara||
+|Welison Almeida||
+
 # Planejamento da Sprint
 |Par|História|Pontos|
 |---|:------:|:----:|

--- a/docs/docs/sprint13.md
+++ b/docs/docs/sprint13.md
@@ -4,6 +4,20 @@ title: Sprint 13 - 10/11 - 17/11
 sidebar_label: Sprint 13
 ---
 
+# Lista de presença no planejamento
+|Nome|Presença|
+|----|:------:|
+|Lucas Costa||
+|Lucas Pereira||
+|Ricardo Canela||
+|Wesley Araújo||
+|André Pinto||
+|Dâmaso Pereira||
+|Gustavo Lima||
+|Leonardo Medeiros||
+|Shayane Alcântara||
+|Welison Almeida||
+
 # Planejamento da Sprint
 |Par|História|Pontos|
 |---|:------:|:----:|

--- a/docs/docs/sprint14.md
+++ b/docs/docs/sprint14.md
@@ -4,6 +4,20 @@ title: Sprint 14 - 17/11 - 24/11
 sidebar_label: Sprint 14
 ---
 
+# Lista de presença no planejamento
+|Nome|Presença|
+|----|:------:|
+|Lucas Costa||
+|Lucas Pereira||
+|Ricardo Canela||
+|Wesley Araújo||
+|André Pinto||
+|Dâmaso Pereira||
+|Gustavo Lima||
+|Leonardo Medeiros||
+|Shayane Alcântara||
+|Welison Almeida||
+
 # Planejamento da Sprint
 |Par|História|Pontos|
 |---|:------:|:----:|

--- a/docs/docs/sprint8.md
+++ b/docs/docs/sprint8.md
@@ -7,16 +7,16 @@ sidebar_label: Sprint 8
 # Lista de presença no planejamento
 |Nome|Presença|
 |----|:------:|
-|Lucas Costa||
-|Lucas Pereira||
-|Ricardo Canela||
-|Wesley Araújo||
-|André Pinto||
-|Dâmaso Pereira||
-|Gustavo Lima||
-|Leonardo Medeiros||
-|Shayane Alcântara||
-|Welison Almeida||
+|Lucas Costa|OK|
+|Lucas Pereira|OK|
+|Ricardo Canela|OK|
+|Wesley Araújo|Faltou|
+|André Pinto|OK|
+|Dâmaso Pereira|OK|
+|Gustavo Lima|Faltou|
+|Leonardo Medeiros|Faltou|
+|Shayane Alcântara|OK|
+|Welison Almeida|OK|
 
 # Planejamento da Sprint
 |Par|História|Pontos|

--- a/docs/docs/sprint8.md
+++ b/docs/docs/sprint8.md
@@ -14,16 +14,23 @@ sidebar_label: Sprint 8
 -------------------------------------------------------------------------------
 # Retrospectiva da Sprint
 ## Pontos positivos
-1. 
+1. A equipe está bem confortável com as tecnologias usadas;
+2. Ambiente de homologação;
+3. Histórias sendo entregues;
+4. Comunicação da equipe.
 
 ## Pontos de melhoria
-1. 
+1. A equipe está perdendo o compromisso com as reuniões;
+2. Atrasos e faltas na planning;
+3. Demora na retrospectiva.
 
 ## Medidas a serem tomadas
-1. 
+1. Melhorar compromisso com os rituais;
+2. Lista de chamada da planning;
+3. Pensar nos tópicos da retrospectiva com antecedência.
 
 ## Melhorias
-1. 
+1. Melhora na comunicação no git com labels e templates para documentar melhor as atividades.
 
 -------------------------------------------------------------------------------
 # Revisão da Sprint

--- a/docs/docs/sprint8.md
+++ b/docs/docs/sprint8.md
@@ -4,6 +4,20 @@ title: Sprint 8 - 06/10 - 13/10
 sidebar_label: Sprint 8
 ---
 
+# Lista de presença no planejamento
+|Nome|Presença|
+|----|:------:|
+|Lucas Costa||
+|Lucas Pereira||
+|Ricardo Canela||
+|Wesley Araújo||
+|André Pinto||
+|Dâmaso Pereira||
+|Gustavo Lima||
+|Leonardo Medeiros||
+|Shayane Alcântara||
+|Welison Almeida||
+
 # Planejamento da Sprint
 |Par|História|Pontos|
 |---|:------:|:----:|

--- a/docs/docs/sprint9.md
+++ b/docs/docs/sprint9.md
@@ -4,6 +4,20 @@ title: Sprint 9 - 13/10 - 20/10
 sidebar_label: Sprint 9
 ---
 
+# Lista de presença no planejamento
+|Nome|Presença|
+|----|:------:|
+|Lucas Costa||
+|Lucas Pereira||
+|Ricardo Canela||
+|Wesley Araújo||
+|André Pinto||
+|Dâmaso Pereira||
+|Gustavo Lima||
+|Leonardo Medeiros||
+|Shayane Alcântara||
+|Welison Almeida||
+
 # Planejamento da Sprint
 |Par|História|Pontos|
 |---|:------:|:----:|


### PR DESCRIPTION
## Descrição
Documentando Sprint 8 no GH Pages do repositório.

**Caso issue esteja no mesmo repositorio**
soluciona issue #243 

Tarefas gerais realizadas
* Readequar gráficos das métricas para contemplarem as sprints da R2;
* Definição do template do quadro de presença nas plannings;
* Documentação da sprint 8.
